### PR TITLE
Crd toggle traefik2

### DIFF
--- a/dts-traefik/templates/crd/ingressroute.yaml
+++ b/dts-traefik/templates/crd/ingressroute.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crd }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -10,3 +11,5 @@ spec:
     plural: ingressroutes
     singular: ingressroute
   scope: Namespaced
+  {{- end -}}
+

--- a/dts-traefik/templates/crd/ingressroutetcp.yaml
+++ b/dts-traefik/templates/crd/ingressroutetcp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crd }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -10,3 +11,4 @@ spec:
     plural: ingressroutetcps
     singular: ingressroutetcp
   scope: Namespaced
+{{- end -}}

--- a/dts-traefik/templates/crd/middlewares.yaml
+++ b/dts-traefik/templates/crd/middlewares.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crd }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -10,3 +11,4 @@ spec:
     plural: middlewares
     singular: middleware
   scope: Namespaced
+  {{- end -}}

--- a/dts-traefik/templates/crd/tlsoptions.yaml
+++ b/dts-traefik/templates/crd/tlsoptions.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crd }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -10,3 +11,4 @@ spec:
     plural: tlsoptions
     singular: tlsoption
   scope: Namespaced
+  {{- end -}}

--- a/dts-traefik/templates/crd/traefikservice.yaml
+++ b/dts-traefik/templates/crd/traefikservice.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crd }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -10,3 +11,4 @@ spec:
     plural: traefikservices
     singular: traefikservice
   scope: Namespaced
+  {{- end -}}

--- a/dts-traefik/values.yaml
+++ b/dts-traefik/values.yaml
@@ -81,4 +81,7 @@ resources: {}
 affinity: {}
 nodeSelector: {}
 tolerations: []
+# Toggle this to 'TRUE' if you have not yet deployed the custom resource definitions to your cluster.
+# to check, run `kubectl get crd`. custom resource definitions are required to get this installation of
+# traefik to work
 crd: false

--- a/dts-traefik/values.yaml
+++ b/dts-traefik/values.yaml
@@ -19,7 +19,6 @@ rollingUpdate:
 # Additional arguments to be passed at Traefik's binary
 ## Use curly braces to pass values: `helm install --set="{--providers.kubernetesingress,--global.checknewversion=true}" ."
 additionalArguments:
-  - "--api.insecure=true"
   - "--accesslog"
 #  - "--providers.kubernetesingress"
 
@@ -82,3 +81,4 @@ resources: {}
 affinity: {}
 nodeSelector: {}
 tolerations: []
+crd: false


### PR DESCRIPTION
Added a root level value to enable/disable the creation of custom resources. Because custom resources are cluster wide, deploying  this chart multiple times would fail because of the overlapping crd definitions. To redeploy the custom resource definitions, set `crd: true`